### PR TITLE
[2022.11.14] Feat: MainPage 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drawingonair-frontend",
-  "version": "0.2.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "drawingonair-frontend",
-      "version": "0.2.0",
+      "version": "0.5.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
@@ -16,6 +16,7 @@
         "react-icons": "^4.6.0",
         "react-router-dom": "^6.4.3",
         "react-scripts": "5.0.1",
+        "react-webcam": "^7.0.1",
         "styled-components": "^5.3.6"
       },
       "devDependencies": {
@@ -14481,6 +14482,15 @@
         }
       }
     },
+    "node_modules/react-webcam": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-webcam/-/react-webcam-7.0.1.tgz",
+      "integrity": "sha512-8E/Eb/7ksKwn5QdLn67tOR7+TdP9BZdu6E5/DSt20v8yfW/s0VGBigE6VA7R4278mBuBUowovAB3DkCfVmSPvA==",
+      "peerDependencies": {
+        "react": ">=16.2.0",
+        "react-dom": ">=16.2.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -27445,6 +27455,12 @@
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
       }
+    },
+    "react-webcam": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-webcam/-/react-webcam-7.0.1.tgz",
+      "integrity": "sha512-8E/Eb/7ksKwn5QdLn67tOR7+TdP9BZdu6E5/DSt20v8yfW/s0VGBigE6VA7R4278mBuBUowovAB3DkCfVmSPvA==",
+      "requires": {}
     },
     "read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drawingonair-frontend",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "contributors": [
     {
       "name": "양선종",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-icons": "^4.6.0",
     "react-router-dom": "^6.4.3",
     "react-scripts": "5.0.1",
+    "react-webcam": "^7.0.1",
     "styled-components": "^5.3.6"
   },
   "scripts": {

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -5,9 +5,9 @@ import styled from "styled-components";
 
 import GlobalStyle from "./GlobalStyle";
 import HomePage from "../pages/HomePage";
+import MainPage from "../pages/MainPage";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
-import MainPage from "../pages/MainPage";
 
 function App() {
   return (

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Route, Routes } from "react-router-dom";
 
 import styled from "styled-components";
 
@@ -6,6 +7,7 @@ import GlobalStyle from "./GlobalStyle";
 import HomePage from "../pages/HomePage";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
+import MainPage from "../pages/MainPage";
 
 function App() {
   return (
@@ -13,7 +15,10 @@ function App() {
       <GlobalStyle />
       <MainSection>
         <Header />
-        <HomePage />
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/main" element={<MainPage />} />
+        </Routes>
         <Footer />
       </MainSection>
     </AppContainer>

--- a/src/components/ColorBar.js
+++ b/src/components/ColorBar.js
@@ -1,0 +1,35 @@
+import React from "react";
+
+import styled from "styled-components";
+
+import CIRCLE_COLORS from "../config/circleColors";
+
+function ColorBar() {
+  return (
+    <ColorContainer>
+      {CIRCLE_COLORS.map((color) => {
+        return <ColorCircle color={color} />;
+      })}
+    </ColorContainer>
+  );
+}
+
+const ColorContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  position: absolute;
+  bottom: 1%;
+  width: 100%;
+  z-index: 9999;
+`;
+
+const ColorCircle = styled.div`
+  width: 1.5rem;
+  height: 1.5rem;
+  margin: 0 0.5rem 0 0.5rem;
+  border-radius: 50%;
+  background-color: ${(props) => props.color};
+  cursor: pointer;
+`;
+
+export default ColorBar;

--- a/src/components/LineBar.js
+++ b/src/components/LineBar.js
@@ -9,7 +9,7 @@ function LineBar() {
   return (
     <LineContainer>
       {LINE_THICKNESSES.map((thickness) => {
-        return <LineWidth thickness={thickness} />;
+        return <LineThickness thickness={thickness} />;
       })}
     </LineContainer>
   );
@@ -24,7 +24,7 @@ const LineContainer = styled.div`
   z-index: 9999;
 `;
 
-const LineWidth = styled.div`
+const LineThickness = styled.div`
   width: ${(props) => props.thickness};
   height: 3rem;
   margin: 0 3rem 0 1rem;

--- a/src/components/LineBar.js
+++ b/src/components/LineBar.js
@@ -1,0 +1,36 @@
+import React from "react";
+
+import styled from "styled-components";
+
+import LINE_THICKNESSES from "../config/lineThicknesses";
+import PAGE_COLORS from "../config/pageColors";
+
+function LineBar() {
+  return (
+    <LineContainer>
+      {LINE_THICKNESSES.map((thickness) => {
+        return <LineWidth thickness={thickness} />;
+      })}
+    </LineContainer>
+  );
+}
+
+const LineContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  position: absolute;
+  top: 1%;
+  width: 100%;
+  z-index: 9999;
+`;
+
+const LineWidth = styled.div`
+  width: ${(props) => props.thickness};
+  height: 3rem;
+  margin: 0 3rem 0 1rem;
+  background-color: ${PAGE_COLORS.FONT_COLOR};
+  transform: rotate(-45deg);
+  cursor: pointer;
+`;
+
+export default LineBar;

--- a/src/config/circleColors.js
+++ b/src/config/circleColors.js
@@ -1,0 +1,12 @@
+const CIRCLE_COLORS = [
+  "#000000",
+  "#ff0000",
+  "#ff8c00",
+  "#ffff00",
+  "#008000",
+  "#0000ff",
+  "#4b0082",
+  "#800080",
+];
+
+export default CIRCLE_COLORS;

--- a/src/config/lineThicknesses.js
+++ b/src/config/lineThicknesses.js
@@ -1,0 +1,3 @@
+const LINE_THICKNESSES = ["1px", "2px", "3px", "4px", "5px"];
+
+export default LINE_THICKNESSES;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter as Router } from "react-router-dom";
 
 import App from "./app/App";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <Router>
+      <App />
+    </Router>
   </React.StrictMode>,
 );

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -1,0 +1,44 @@
+import React from "react";
+import WebCam from "react-webcam";
+
+import styled from "styled-components";
+
+import LineBar from "../components/LineBar";
+import ColorBar from "../components/ColorBar";
+
+function MainPage() {
+  return (
+    <MainPageContainer>
+      <WebCamera />
+      <Canvas />
+      <LineBar />
+      <ColorBar />
+    </MainPageContainer>
+  );
+}
+
+const MainPageContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+const WebCamera = styled(WebCam)`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transform: rotateY(180deg);
+  z-index: 9999;
+`;
+
+const Canvas = styled.canvas`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transform: rotateY(180deg);
+  z-index: 9999;
+`;
+
+export default MainPage;


### PR DESCRIPTION
## Task
MainPage 작업 진행
## Description
1. React-Router 설정
> 페이지 작업 분리를 위하여 React_router를 설정하였습니다.
> /main을 통해 MainPage 접근이 가능합니다.

2. MainPage 구성
목업으로 작성해둔 레이아웃을 바탕으로
webcam, canvas, linebar, colorbar를 넣었습니다.
> webcam 과 canvas의 경우 크기를 동일시하여 같은 선상에서 작업이 가능하도록 진행합니다.

> linebar와 colorbar의 경우 추후 작업 진행을 위해 따로 컴포넌트로 분리 하였으며 Tenserflow 모델 후에 재작업이 진행될 예정입니다. 

## Desigin
![image](https://user-images.githubusercontent.com/76609548/201542166-e648baa0-d5ad-4f0b-81e8-b35452732c84.png)

