### PR TITLE
[2022.11.21] Fix: CompositeOption 기능에 대한 재수정 작업

### DIFF
--- a/src/utils/adaptCompositingType.js
+++ b/src/utils/adaptCompositingType.js
@@ -15,7 +15,7 @@ const adaptCompositingType = (
       const maximumY = arr.reduce((a, b) => Math.max(a, b[1]), -Infinity);
       const minimumY = arr.reduce((a, b) => Math.min(a, b[1]), Infinity);
 
-      context.storkeStyle = arr[0][2];
+      context.strokeStyle = arr[0][2];
       context.lineWidth = arr[0][3];
 
       if (x > originX && y > originY) {
@@ -26,36 +26,12 @@ const adaptCompositingType = (
           minimumY <= y
         ) {
           if (!arr[0][4]) {
-            context.globalCompositeOperation = compositingType;
             arr[0][4] = compositingType;
 
             if (index === 0) {
               arr[0][4] = "source-over";
-              context.globalCompositeOperation = "source-over";
-            }
-          } else {
-            context.globalCompositeOperation = arr[0][4];
-          }
-
-          context.beginPath();
-          context.moveTo(arr[0][0], arr[0][1]);
-
-          for (let i = 1; i < arr.length; i += 1) {
-            context.lineTo(arr[i][0], arr[i][1]);
-            context.stroke();
-
-            if (
-              arr[i][0] - 5 < Math.floor(arr[0][0]) &&
-              Math.floor(arr[0][0]) < arr[i][0] + 5 &&
-              arr[i][1] - 5 < Math.floor(arr[0][1]) &&
-              Math.floor(arr[0][1]) < arr[i][1] + 5
-            ) {
-              context.fillStyle = arr[0][2];
-              context.fill();
             }
           }
-
-          context.globalCompositeOperation = "source-over";
         }
       }
 
@@ -67,36 +43,12 @@ const adaptCompositingType = (
           minimumY <= originY
         ) {
           if (!arr[0][4]) {
-            context.globalCompositeOperation = compositingType;
             arr[0][4] = compositingType;
 
             if (index === 0) {
               arr[0][4] = "source-over";
-              context.globalCompositeOperation = "source-over";
-            }
-          } else {
-            context.globalCompositeOperation = arr[0][4];
-          }
-
-          context.beginPath();
-          context.moveTo(arr[0][0], arr[0][1]);
-
-          for (let i = 1; i < arr.length; i += 1) {
-            context.lineTo(arr[i][0], arr[i][1]);
-            context.stroke();
-
-            if (
-              arr[i][0] - 5 < Math.floor(arr[0][0]) &&
-              Math.floor(arr[0][0]) < arr[i][0] + 5 &&
-              arr[i][1] - 5 < Math.floor(arr[0][1]) &&
-              Math.floor(arr[0][1]) < arr[i][1] + 5
-            ) {
-              context.fillStyle = arr[0][2];
-              context.fill();
             }
           }
-
-          context.globalCompositeOperation = "source-over";
         }
       }
 
@@ -108,36 +60,12 @@ const adaptCompositingType = (
           minimumX <= y
         ) {
           if (!arr[0][4]) {
-            context.globalCompositeOperation = compositingType;
             arr[0][4] = compositingType;
 
             if (index === 0) {
               arr[0][4] = "source-over";
-              context.globalCompositeOperation = "source-over";
-            }
-          } else {
-            context.globalCompositeOperation = arr[0][4];
-          }
-
-          context.beginPath();
-          context.moveTo(arr[0][0], arr[0][1]);
-
-          for (let i = 1; i < arr.length; i += 1) {
-            context.lineTo(arr[i][0], arr[i][1]);
-            context.stroke();
-
-            if (
-              arr[i][0] - 5 < Math.floor(arr[0][0]) &&
-              Math.floor(arr[0][0]) < arr[i][0] + 5 &&
-              arr[i][1] - 5 < Math.floor(arr[0][1]) &&
-              Math.floor(arr[0][1]) < arr[i][1] + 5
-            ) {
-              context.fillStyle = arr[0][2];
-              context.fill();
             }
           }
-
-          context.globalCompositeOperation = "source-over";
         }
       }
 
@@ -148,38 +76,20 @@ const adaptCompositingType = (
           maximumY >= y &&
           minimumY <= originY
         ) {
-          if (!arr[0][2]) {
-            context.globalCompositeOperation = compositingType;
-            arr[0][2] = compositingType;
+          if (!arr[0][4]) {
+            arr[0][4] = compositingType;
 
             if (index === 0) {
-              arr[0][2] = "source-over";
-              context.globalCompositeOperation = "source-over";
-            }
-          } else {
-            context.globalCompositeOperation = arr[0][4];
-          }
-
-          context.beginPath();
-          context.moveTo(arr[0][0], arr[0][1]);
-
-          for (let i = 1; i < arr.length; i += 1) {
-            context.lineTo(arr[i][0], arr[i][1]);
-            context.stroke();
-            if (
-              arr[i][0] - 5 < Math.floor(arr[0][0]) &&
-              Math.floor(arr[0][0]) < arr[i][0] + 5 &&
-              arr[i][1] - 5 < Math.floor(arr[0][1]) &&
-              Math.floor(arr[0][1]) < arr[i][1] + 5
-            ) {
-              context.fillStyle = arr[0][2];
-              context.fill();
+              arr[0][4] = "source-over";
             }
           }
-
-          context.globalCompositeOperation = "source-over";
         }
       }
+
+      if (arr[0][4]) {
+        context.globalCompositeOperation = arr[0][4];
+      }
+
       context.beginPath();
       context.moveTo(arr[0][0], arr[0][1]);
 
@@ -197,9 +107,11 @@ const adaptCompositingType = (
           context.fill();
         }
       }
+
+      context.globalCompositeOperation = "source-over";
+
       return arr;
     });
-    return pathsry;
   }
   return pathsry;
 };

--- a/src/utils/drawWithHand.js
+++ b/src/utils/drawWithHand.js
@@ -29,7 +29,7 @@ const drawWithHand = (
     points.push([originX, originY, canvasColor, canvasLineThickness]);
   }
 
-  if (gesture === "start") {
+  if (gesture === "clear") {
     context.clearRect(0, 0, width, height);
     context.beginPath();
     pathsry = [];


### PR DESCRIPTION
## Task
CompositeOption 기능에 대한 재수정 작업

## Description
작성 했던 로직에서 생겨나는 문제점들에 대한 전반 적인 수정을 완료하였습니다.

문제를 확인해 본 결과

아래의 로직이 총 두번 실행됨으로써 원치 않은 결과가 자주 발생하는 것을 인지하였습니다.
`
context.beginPath();
context.moveTo(arr[0][0], arr[0][1]);

      for (let i = 1; i < arr.length; i += 1) {
        context.lineTo(arr[i][0], arr[i][1]);
        context.stroke();

        if (
          arr[i][0] - 5 < Math.floor(arr[0][0]) &&
          Math.floor(arr[0][0]) < arr[i][0] + 5 &&
          arr[i][1] - 5 < Math.floor(arr[0][1]) &&
          Math.floor(arr[0][1]) < arr[i][1] + 5
        ) {
          context.fillStyle = arr[0][2];
          context.fill();
        }
      }

      context.globalCompositeOperation = "source-over";
`
이에 따라 불필요한 부분에 대한 작업을 생략하여 버그를 최소화 하였습니다.