### PR TITLE
[2022.11.22] Feat: 충돌 방지 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drawingonair-frontend",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "contributors": [
     {
       "name": "양선종",

--- a/src/config/handsId.js
+++ b/src/config/handsId.js
@@ -1,0 +1,19 @@
+const HANDS_ID = [
+  {
+    id: "originCanvas",
+  },
+  {
+    id: "rightCanvas",
+  },
+  {
+    id: "rightSubCanvas",
+  },
+  {
+    id: "leftCanvas",
+  },
+  {
+    id: "leftSubCanvas",
+  },
+];
+
+export default HANDS_ID;

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -18,15 +18,15 @@ import HANDS_ID from "../config/handsId";
 function MainPage() {
   const dispatch = useDispatch();
 
+  const [contextArray, setcontextArray] = useState([]);
   const [neuralNet, setNeuralNet] = useState(null);
   const [webCam, setWebCam] = useState(null);
-  const [contextArray, setcontextArray] = useState([]);
   const [canvasWidth, setCanvasWidth] = useState(null);
   const [canvasHeight, setCanvasHeight] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  const webcamRef = useRef(null);
   const canvasRefs = useRef([]);
+  const webcamRef = useRef(null);
 
   const compositingType = useSelector((state) => state.compositingData);
   const canvasColor = useSelector((state) => state.selectingColor);

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -13,21 +13,20 @@ import CompositingBar from "../components/CompositingBar";
 import LoadingSpinner from "../components/LoadingSpinner";
 import * as fingerPose from "../Fingerpose";
 import { getMainTag } from "../features/getMainDataReducer";
+import HANDS_ID from "../config/handsId";
 
 function MainPage() {
   const dispatch = useDispatch();
 
   const [neuralNet, setNeuralNet] = useState(null);
-  const [ctx, setCtx] = useState(null);
-  const [newCtx, setNewCtx] = useState(null);
   const [webCam, setWebCam] = useState(null);
+  const [ctxArray, setCtxArray] = useState([]);
   const [canvasWidth, setCanvasWidth] = useState(null);
   const [canvasHeight, setCanvasHeight] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
   const webcamRef = useRef(null);
-  const canvasRef = useRef(null);
-  const newCanvasRef = useRef(null);
+  const canvasRefs = useRef([]);
 
   const compositingType = useSelector((state) => state.compositingData);
   const canvasColor = useSelector((state) => state.selectingColor);
@@ -36,16 +35,16 @@ function MainPage() {
   );
 
   useEffect(() => {
-    dispatch(getMainTag(canvasRef));
+    dispatch(getMainTag(canvasRefs.current[0]));
   }, [dispatch]);
 
   const detect = async (network, video) => {
-    const hand = await network.estimateHands(video);
+    const hands = await network.estimateHands(video);
     if (isLoading) {
       setIsLoading(false);
     }
 
-    if (hand.length > 0) {
+    if (hands.length > 0) {
       const GE = new fingerPose.GestureEstimator([
         fingerPose.Gestures.DrawGesture,
         fingerPose.Gestures.NoneGesture,
@@ -53,28 +52,50 @@ function MainPage() {
         fingerPose.Gestures.ClearGesture,
         fingerPose.Gestures.ExampleGesture,
       ]);
-      const gesture = GE.estimate(hand[0], 8);
+      hands.forEach((hand) => {
+        const gesture = GE.estimate(hand, 8);
 
-      if (gesture.gestures !== undefined && gesture.gestures.length > 0) {
-        const confidence = gesture.gestures.map(
-          (prediction) => prediction.score,
-        );
-        const maxConfidence = confidence.indexOf(
-          Math.max.apply(null, confidence),
-        );
+        if (gesture.gestures !== undefined && gesture.gestures.length > 0) {
+          const confidence = gesture.gestures.map(
+            (prediction) => prediction.score,
+          );
+          const maxConfidence = confidence.indexOf(
+            Math.max.apply(null, confidence),
+          );
 
-        drawWithHand(
-          hand,
-          ctx,
-          gesture.gestures[maxConfidence].name,
-          canvasWidth,
-          canvasHeight,
-          newCtx,
-          compositingType,
-          canvasColor,
-          canvasLineThickness,
-        );
-      }
+          if (hand.handedness === "Right") {
+            drawWithHand(
+              hand,
+              ctxArray[0],
+              ctxArray[1],
+              ctxArray[2],
+              gesture.gestures[maxConfidence].name,
+              canvasWidth,
+              canvasHeight,
+              compositingType,
+              canvasColor,
+              canvasLineThickness,
+              hand.handedness,
+            );
+          }
+
+          if (hand.handedness === "Left") {
+            drawWithHand(
+              hand,
+              ctxArray[0],
+              ctxArray[3],
+              ctxArray[4],
+              gesture.gestures[maxConfidence].name,
+              canvasWidth,
+              canvasHeight,
+              compositingType,
+              canvasColor,
+              canvasLineThickness,
+              hand.handedness,
+            );
+          }
+        }
+      });
     }
   };
 
@@ -91,20 +112,20 @@ function MainPage() {
       webcamRef.current.video.width = videoWidth;
       webcamRef.current.video.height = videoHeight;
 
-      canvasRef.current.width = videoWidth;
-      canvasRef.current.height = videoHeight;
+      webcamRef.current.video.width = videoWidth;
+      webcamRef.current.video.height = videoHeight;
 
-      newCanvasRef.current.width = videoWidth;
-      newCanvasRef.current.height = videoHeight;
+      const canvasArray = canvasRefs.current.map((canvasRef) => {
+        canvasRef.width = videoWidth;
+        canvasRef.height = videoHeight;
 
-      const context = canvasRef.current.getContext("2d");
-      const newContext = newCanvasRef.current.getContext("2d");
+        return canvasRef.getContext("2d");
+      });
 
       setCanvasWidth(videoWidth);
       setCanvasHeight(videoHeight);
       setWebCam(video);
-      setNewCtx(newContext);
-      setCtx(context);
+      setCtxArray(canvasArray);
     }
   };
 
@@ -120,7 +141,7 @@ function MainPage() {
   }, []);
 
   useInterval(() => {
-    if (!ctx) {
+    if (ctxArray.length === 0) {
       setCanvasAndWebCam();
     }
 
@@ -136,8 +157,17 @@ function MainPage() {
       ) : (
         <>
           <WebCamera ref={webcamRef} />
-          <Canvas ref={canvasRef} />
-          <NewCanvas ref={newCanvasRef} />
+          {HANDS_ID.map((hand, index) => {
+            return (
+              <Canvas
+                key={hand.id}
+                id={hand.id}
+                ref={(element) => {
+                  canvasRefs.current[index] = element;
+                }}
+              />
+            );
+          })}
           <CompositingBar />
           <LineBar />
           <ColorBar />
@@ -167,15 +197,6 @@ const Canvas = styled.canvas`
   width: 100%;
   height: 100%;
   bottom: 0%;
-  text-align: center;
-  transform: rotateY(180deg);
-  z-index: 9999;
-`;
-
-const NewCanvas = styled.canvas`
-  position: absolute;
-  width: 100%;
-  height: 100%;
   text-align: center;
   transform: rotateY(180deg);
   z-index: 9999;

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -20,7 +20,7 @@ function MainPage() {
 
   const [neuralNet, setNeuralNet] = useState(null);
   const [webCam, setWebCam] = useState(null);
-  const [ctxArray, setCtxArray] = useState([]);
+  const [contextArray, setcontextArray] = useState([]);
   const [canvasWidth, setCanvasWidth] = useState(null);
   const [canvasHeight, setCanvasHeight] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -66,9 +66,9 @@ function MainPage() {
           if (hand.handedness === "Right") {
             drawWithHand(
               hand,
-              ctxArray[0],
-              ctxArray[1],
-              ctxArray[2],
+              contextArray[0],
+              contextArray[1],
+              contextArray[2],
               gesture.gestures[maxConfidence].name,
               canvasWidth,
               canvasHeight,
@@ -82,9 +82,9 @@ function MainPage() {
           if (hand.handedness === "Left") {
             drawWithHand(
               hand,
-              ctxArray[0],
-              ctxArray[3],
-              ctxArray[4],
+              contextArray[0],
+              contextArray[3],
+              contextArray[4],
               gesture.gestures[maxConfidence].name,
               canvasWidth,
               canvasHeight,
@@ -122,7 +122,7 @@ function MainPage() {
       setCanvasWidth(videoWidth);
       setCanvasHeight(videoHeight);
       setWebCam(video);
-      setCtxArray(canvasArray);
+      setcontextArray(canvasArray);
     }
   };
 
@@ -138,7 +138,7 @@ function MainPage() {
   }, []);
 
   useInterval(() => {
-    if (ctxArray.length === 0) {
+    if (contextArray.length === 0) {
       setCanvasAndWebCam();
     }
 

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -112,9 +112,6 @@ function MainPage() {
       webcamRef.current.video.width = videoWidth;
       webcamRef.current.video.height = videoHeight;
 
-      webcamRef.current.video.width = videoWidth;
-      webcamRef.current.video.height = videoHeight;
-
       const canvasArray = canvasRefs.current.map((canvasRef) => {
         canvasRef.width = videoWidth;
         canvasRef.height = videoHeight;

--- a/src/utils/adaptCompositingType.js
+++ b/src/utils/adaptCompositingType.js
@@ -1,9 +1,11 @@
 /* eslint-disable prefer-destructuring */
+import checkOwnCompositingType from "./checkOwnCompositingType";
+import drawData from "./drawData";
 
 const adaptCompositingType = (
   pathsry,
-  x,
-  y,
+  draggingAreaX,
+  draggingAreaY,
   originX,
   originY,
   context,
@@ -16,100 +18,50 @@ const adaptCompositingType = (
       const maximumY = arr.reduce((a, b) => Math.max(a, b[1]), -Infinity);
       const minimumY = arr.reduce((a, b) => Math.min(a, b[1]), Infinity);
 
-      context.strokeStyle = arr[0][2];
-      context.lineWidth = arr[0][3];
-
-      if (x > originX && y > originY) {
+      if (draggingAreaX > originX && draggingAreaY > originY) {
         if (
           maximumX >= originX &&
-          minimumX <= x &&
+          minimumX <= draggingAreaX &&
           maximumY >= originY &&
-          minimumY <= y
+          minimumY <= draggingAreaY
         ) {
-          if (!arr[0][4]) {
-            arr[0][4] = compositingType;
-
-            if (index === 0) {
-              arr[0][4] = "source-over";
-            }
-          }
+          checkOwnCompositingType(arr, index, compositingType);
         }
       }
 
-      if (x > originX && y < originY) {
+      if (draggingAreaX > originX && draggingAreaY < originY) {
         if (
           maximumX >= originX &&
-          minimumX <= x &&
-          maximumY >= y &&
+          minimumX <= draggingAreaX &&
+          maximumY >= draggingAreaY &&
           minimumY <= originY
         ) {
-          if (!arr[0][4]) {
-            arr[0][4] = compositingType;
-
-            if (index === 0) {
-              arr[0][4] = "source-over";
-            }
-          }
+          checkOwnCompositingType(arr, index, compositingType);
         }
       }
 
-      if (x < originX && y > originY) {
+      if (draggingAreaX < originX && draggingAreaY > originY) {
         if (
-          maximumX >= x &&
+          maximumX >= draggingAreaX &&
           minimumX <= originX &&
           maximumY >= originY &&
-          minimumX <= y
+          minimumX <= draggingAreaY
         ) {
-          if (!arr[0][4]) {
-            arr[0][4] = compositingType;
-
-            if (index === 0) {
-              arr[0][4] = "source-over";
-            }
-          }
+          checkOwnCompositingType(arr, index, compositingType);
         }
       }
 
-      if (x < originX && y < originY) {
+      if (draggingAreaX < originX && draggingAreaY < originY) {
         if (
-          maximumX >= x &&
+          maximumX >= draggingAreaX &&
           minimumX <= originX &&
-          maximumY >= y &&
+          maximumY >= draggingAreaY &&
           minimumY <= originY
         ) {
-          if (!arr[0][4]) {
-            arr[0][4] = compositingType;
-
-            if (index === 0) {
-              arr[0][4] = "source-over";
-            }
-          }
+          checkOwnCompositingType(arr, index, compositingType);
         }
       }
-
-      if (arr[0][4]) {
-        context.globalCompositeOperation = arr[0][4];
-      }
-
-      context.beginPath();
-      context.moveTo(arr[0][0], arr[0][1]);
-
-      for (let i = 1; i < arr.length; i += 1) {
-        context.lineTo(arr[i][0], arr[i][1]);
-        context.stroke();
-
-        if (
-          arr[i][0] - 5 < Math.floor(arr[0][0]) &&
-          Math.floor(arr[0][0]) < arr[i][0] + 5 &&
-          arr[i][1] - 5 < Math.floor(arr[0][1]) &&
-          Math.floor(arr[0][1]) < arr[i][1] + 5
-        ) {
-          context.fillStyle = arr[0][2];
-          context.fill();
-        }
-      }
-
-      context.globalCompositeOperation = "source-over";
+      drawData(context, arr);
 
       return arr;
     });

--- a/src/utils/adaptCompositingType.js
+++ b/src/utils/adaptCompositingType.js
@@ -1,4 +1,3 @@
-/* eslint-disable prefer-destructuring */
 import checkOwnCompositingType from "./checkOwnCompositingType";
 import drawData from "./drawData";
 

--- a/src/utils/checkOwnCompositingType.js
+++ b/src/utils/checkOwnCompositingType.js
@@ -1,0 +1,11 @@
+const checkOwnCompositingType = (drawingDataArray, index, compositingType) => {
+  if (!drawingDataArray[0][4]) {
+    drawingDataArray[0][4] = compositingType;
+
+    if (index === 0) {
+      drawingDataArray[0][4] = "source-over";
+    }
+  }
+};
+
+export default checkOwnCompositingType;

--- a/src/utils/drawData.js
+++ b/src/utils/drawData.js
@@ -1,0 +1,30 @@
+/* eslint-disable prefer-destructuring */
+
+const drawData = (context, drawingDataArray) => {
+  if (drawingDataArray[0][4]) {
+    context.globalCompositeOperation = drawingDataArray[0][4];
+  }
+  context.strokeStyle = drawingDataArray[0][2];
+  context.lineWidth = drawingDataArray[0][3];
+  context.beginPath();
+  context.moveTo(drawingDataArray[0][0], drawingDataArray[0][1]);
+
+  for (let i = 1; i < drawingDataArray.length; i += 1) {
+    context.lineTo(drawingDataArray[i][0], drawingDataArray[i][1]);
+    context.stroke();
+
+    if (
+      drawingDataArray[i][0] - 5 < Math.floor(drawingDataArray[0][0]) &&
+      Math.floor(drawingDataArray[0][0]) < drawingDataArray[i][0] + 5 &&
+      drawingDataArray[i][1] - 5 < Math.floor(drawingDataArray[0][1]) &&
+      Math.floor(drawingDataArray[0][1]) < drawingDataArray[i][1] + 5
+    ) {
+      context.fillStyle = drawingDataArray[0][2];
+      context.fill();
+    }
+  }
+
+  context.globalCompositeOperation = "source-over";
+};
+
+export default drawData;

--- a/src/utils/drawWithHand.js
+++ b/src/utils/drawWithHand.js
@@ -6,11 +6,12 @@ const originX = {};
 const originY = {};
 const draggingAreaX = {};
 const draggingAreaY = {};
-let pathsry = [];
 const points = {
   Right: [],
   Left: [],
 };
+
+let pathsry = [];
 
 const drawWithHand = (
   hand,

--- a/src/utils/drawWithHand.js
+++ b/src/utils/drawWithHand.js
@@ -1,7 +1,6 @@
 import adaptCompositingType from "./adaptCompositingType";
 import drawData from "./drawData";
 
-/* eslint-disable prefer-destructuring */
 const originX = {};
 const originY = {};
 const draggingAreaX = {};

--- a/src/utils/drawWithHand.js
+++ b/src/utils/drawWithHand.js
@@ -28,6 +28,7 @@ const drawWithHand = (
 ) => {
   const { keypoints } = hand;
   const { x, y } = keypoints[8];
+
   drawingContext.strokeStyle = canvasColor;
   drawingContext.lineWidth = canvasLineThickness;
 
@@ -42,14 +43,18 @@ const drawWithHand = (
 
   switch (gesture) {
     case "clear":
+      pathsry = [];
+
       originContext.clearRect(0, 0, canvasWidth, canvasHeight);
       originContext.beginPath();
-      pathsry = [];
+
       break;
     case "draw":
-      drawingContext.lineTo(x, y);
       points[handType].push([x, y]);
+
+      drawingContext.lineTo(x, y);
       drawingContext.stroke();
+
       if (
         x - 5 < Math.floor(originX) &&
         Math.floor(originX) < x + 5 &&
@@ -59,10 +64,12 @@ const drawWithHand = (
         drawingContext.fillStyle = canvasColor;
         drawingContext.fill();
       }
+
       break;
     case "drag":
       draggingAreaX[handType] = x;
       draggingAreaY[handType] = y;
+
       draggingContext.clearRect(0, 0, canvasWidth, canvasHeight);
       draggingContext.strokeRect(
         originX[handType],
@@ -70,10 +77,12 @@ const drawWithHand = (
         x - originX[handType],
         y - originY[handType],
       );
+
       break;
     default:
       if (draggingAreaX[handType] && draggingAreaY[handType]) {
         originContext.clearRect(0, 0, canvasWidth, canvasHeight);
+
         pathsry = adaptCompositingType(
           pathsry,
           draggingAreaX[handType],
@@ -85,19 +94,21 @@ const drawWithHand = (
           canvasColor,
           canvasLineThickness,
         );
+
         draggingAreaX[handType] = null;
         draggingAreaY[handType] = null;
       }
+
       draggingContext.clearRect(0, 0, canvasWidth, canvasHeight);
+
       pathsry = pathsry.map((arr) => {
         drawData(originContext, arr);
-
         return arr;
       });
-      //
 
       originX[handType] = x;
       originY[handType] = y;
+
       drawingContext.beginPath();
       drawingContext.moveTo(originX[handType], originY[handType]);
   }

--- a/src/utils/drawWithHand.js
+++ b/src/utils/drawWithHand.js
@@ -1,93 +1,115 @@
 import adaptCompositingType from "./adaptCompositingType";
+import drawData from "./drawData";
 
 /* eslint-disable prefer-destructuring */
-let originX = null;
-let originY = null;
-let newCanvasX = null;
-let newCanvasY = null;
+const originX = {};
+const originY = {};
+const draggingAreaX = {};
+const draggingAreaY = {};
 let pathsry = [];
-let points = [];
+const points = {
+  Right: [],
+  Left: [],
+};
 
 const drawWithHand = (
   hand,
-  context,
+  originContext,
+  drawingContext,
+  draggingContext,
   gesture,
-  width,
-  height,
-  newContext,
+  canvasWidth,
+  canvasHeight,
   compositingType,
   canvasColor,
   canvasLineThickness,
+  handType,
 ) => {
-  const { keypoints } = hand[0];
+  const { keypoints } = hand;
   const { x, y } = keypoints[8];
+  drawingContext.strokeStyle = canvasColor;
+  drawingContext.lineWidth = canvasLineThickness;
 
-  context.strokeStyle = canvasColor;
-  context.lineWidth = canvasLineThickness;
-
-  if (points.length === 0) {
-    points.push([originX, originY, canvasColor, canvasLineThickness]);
+  if (points[handType].length === 0) {
+    points[handType].push([
+      originX[handType],
+      originY[handType],
+      canvasColor,
+      canvasLineThickness,
+    ]);
   }
 
-  if (gesture === "clear") {
-    context.clearRect(0, 0, width, height);
-    context.beginPath();
-    pathsry = [];
-  }
-
-  if (gesture === "draw") {
-    context.lineTo(x, y);
-    points.push([x, y]);
-    context.stroke();
-    if (
-      x - 5 < Math.floor(originX) &&
-      Math.floor(originX) < x + 5 &&
-      y - 5 < Math.floor(originY) &&
-      Math.floor(originY) < y + 5
-    ) {
-      context.fillStyle = canvasColor;
-      context.fill();
-    }
-  }
-
-  if (gesture === "drag") {
-    newCanvasX = x;
-    newCanvasY = y;
-    newContext.clearRect(0, 0, width, height);
-    newContext.strokeRect(originX, originY, x - originX, y - originY);
-  }
-
-  if (gesture !== "draw" && gesture !== "drag") {
-    if (newCanvasX && newCanvasY) {
-      context.clearRect(0, 0, width, height);
-      pathsry = adaptCompositingType(
-        pathsry,
-        newCanvasX,
-        newCanvasY,
-        originX,
-        originY,
-        context,
-        compositingType,
-        canvasColor,
-        canvasLineThickness,
+  switch (gesture) {
+    case "clear":
+      originContext.clearRect(0, 0, canvasWidth, canvasHeight);
+      originContext.beginPath();
+      pathsry = [];
+      break;
+    case "draw":
+      drawingContext.lineTo(x, y);
+      points[handType].push([x, y]);
+      drawingContext.stroke();
+      if (
+        x - 5 < Math.floor(originX) &&
+        Math.floor(originX) < x + 5 &&
+        y - 5 < Math.floor(originY) &&
+        Math.floor(originY) < y + 5
+      ) {
+        drawingContext.fillStyle = canvasColor;
+        drawingContext.fill();
+      }
+      break;
+    case "drag":
+      draggingAreaX[handType] = x;
+      draggingAreaY[handType] = y;
+      draggingContext.clearRect(0, 0, canvasWidth, canvasHeight);
+      draggingContext.strokeRect(
+        originX[handType],
+        originY[handType],
+        x - originX[handType],
+        y - originY[handType],
       );
-      newCanvasX = null;
-      newCanvasY = null;
-    }
-    newContext.clearRect(0, 0, width, height);
+      break;
+    default:
+      if (draggingAreaX[handType] && draggingAreaY[handType]) {
+        originContext.clearRect(0, 0, canvasWidth, canvasHeight);
+        pathsry = adaptCompositingType(
+          pathsry,
+          draggingAreaX[handType],
+          draggingAreaY[handType],
+          originX[handType],
+          originY[handType],
+          originContext,
+          compositingType,
+          canvasColor,
+          canvasLineThickness,
+        );
+        draggingAreaX[handType] = null;
+        draggingAreaY[handType] = null;
+      }
+      draggingContext.clearRect(0, 0, canvasWidth, canvasHeight);
+      pathsry = pathsry.map((arr) => {
+        drawData(originContext, arr);
 
-    originX = hand[0].keypoints[8].x;
-    originY = hand[0].keypoints[8].y;
-    context.beginPath();
-    context.moveTo(originX, originY);
+        return arr;
+      });
+      //
+
+      originX[handType] = x;
+      originY[handType] = y;
+      drawingContext.beginPath();
+      drawingContext.moveTo(originX[handType], originY[handType]);
   }
 
-  if (points[0][0] !== originX && points[0][1] !== originY) {
-    if (points.length > 3) {
-      pathsry.push(points);
+  if (
+    points[handType][0][0] !== originX[handType] &&
+    points[handType][0][1] !== originY[handType]
+  ) {
+    if (points[handType].length > 3) {
+      pathsry.push(points[handType]);
     }
 
-    points = [];
+    points[handType] = [];
   }
 };
 

--- a/src/utils/setHandsDetector.js
+++ b/src/utils/setHandsDetector.js
@@ -7,7 +7,7 @@ const setHandsDetector = async () => {
   const detectorConfig = {
     runtime: "tfjs",
     modelType: "full",
-    maxHands: 10,
+    maxHands: 2,
   };
   const handsDetector = await handPoseDetection.createDetector(
     hands,


### PR DESCRIPTION
## Task
캔버스에서 두 개의 마우스가 움직이는 것과 유사 하게 양손을 가지고 각각 동시에 다른 그림을 그릴 수 있게 만들기 위한 작업을 진행 하였습니다.

## Description
### 1. 캔버스 세분화 작업
캔버스에서 양손이 다른 그림을 그리기 위해서 캔버스를 세분화 하여 작업을 하였습니다.

그 결과 캔버스가 최종적으로 그림이 그려지는 캔버스, 왼손 오른손 마다 드래그 영역을 그려주는 캔버스, 그림을 그려주는 캔버스를 그리게 되었습니다.

이로 인해 다수의 캔버스에 대한 접근을 하기 위해 각각 useRef로 설정하는 것은 코드 상으로도 좋지 않아 배열의 형태로 재 선언 및 각각의 캔버스에 고유 ID를 주었습니다.

### 2. drawWithHand 함수의 인자에 대한 세분화 작업 및 
A. handness 추가
코드 내역에
`const hands = await network.estimateHands(video)`
를 통해 받아오는 hands는 배열의 결과로 받아오지만 이 결과 값이 항상 동일 하진 않습니다.

양손 작업으로 진행을 해 보았을 때
[오른손, 왼손] , [왼손, 오른손] 두가지 결과 값으로 다양하게 나오기 때문에  배열의 handedness 즉 왼손 오른손 타입을 확인하여 각각 다른 인자를 넘겨 주었습니다.

B. drawWithHand 재 설정
인자의 타입이 달라지고 캔버스가 세분화됨에 따라서 그에 따라 drawWithHand에서 사용되는 변수들의 선언 방식을 다시 설정해 주었습니다.

### 3. 중복 및 반복되는 작업들 재 함수화
코드 내에서 반복적으로 사용되는 코드들이 다수 존재하였고 함수화로 이를 줄이는 작업을 진행했습니다.




